### PR TITLE
Add `libraryTarget: 'umd'` to webpack config

### DIFF
--- a/gulp/config/webpack.config.js
+++ b/gulp/config/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
         app: './src/_module.js'
     },
     output: {
+        libraryTarget: 'umd',
         path: path.join(process.cwd(), '/dist'),
         filename: 'media-events.js'
     },


### PR DESCRIPTION
This allows us to include the module in a rather lovely way like this in webpack:

```
import angularMediaEvents from 'angular-media-events';

angular.module('myApp', [angularMediaEvents]);
```

or in browserify:

```
angular.module('myApp', [require('angular-media-events')]);
```
