### PR TITLE
Fix "main" section of bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,6 @@
   ],
   "license": "MIT",
   "main": [
-    "./src/**",
     "./dist/**"
   ],
   "ignore": [

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "license": "MIT",
   "main": [
-    "./dist/**"
+    "./dist/media-events.js"
   ],
   "ignore": [
     ".jshintrc",


### PR DESCRIPTION
"main" section of bower.json currently lists both "src" & "dist" files.

As a result, when using tools like wiredep to inject <scripts> tags in .html, we end up loading both raw source files & minified transpilled dist files.

Additionally, the "main" section of bower.json cannot contain wildcard patterns (as per https://github.com/bower/spec/blob/master/json.md#main)
